### PR TITLE
fix/EB-3010396678: Update v1 and v2 correct chrome extension link

### DIFF
--- a/src/contexts/usePortkey/provider.tsx
+++ b/src/contexts/usePortkey/provider.tsx
@@ -44,7 +44,9 @@ export function PortkeyReactProvider({ children, networkType: propsNetworkType }
   let portkeyVersion = PortkeyNameVersion.v1;
   const activate = useCallback(
     async (version: PortkeyNameVersion) => {
-      const installed = await evokePortkey.extension();
+      const installed = await evokePortkey.extension({
+        version: version == PortkeyNameVersion.v1 ? 'v1' : undefined,
+      });
       if (!installed) throw Error('provider not installed');
       portkeyVersion = version;
       const provider = await detectProvider({


### PR DESCRIPTION
When portkey v1 and v2 are not installed， on the elastic layer connected wallet, click the portkey， jump to the download link for v2