### PR TITLE
fix/EB-3010404933: when portkey v1 is enable and portkey v2 is disablewhen connect wallet with portkey v1，jumped to download page，it should evoke portkey v1 plugin

### DIFF
--- a/src/contexts/usePortkey/constants.ts
+++ b/src/contexts/usePortkey/constants.ts
@@ -3,6 +3,11 @@ export enum PortkeyNameVersion {
   v2 = 'Portkey',
 }
 
+export enum PortkeyVersion {
+  v1 = 'v1',
+  v2 = 'v2',
+}
+
 export const PORTKEY_APP_DOWNLOAD_PAGE = {
   v1: 'https://chromewebstore.google.com/detail/portkey-wallet-crypto-gam/hpjiiechbbhefmpggegmahejiiphbmij',
   v2: 'https://chromewebstore.google.com/detail/portkey-early-access/iglbgmakmggfkoidiagnhknlndljlolb',


### PR DESCRIPTION
when portkey v1 is enable and portkey v2 is disable，when connect wallet with portkey v1，jumped to download page，it should evoke portkey v1 plugin.