### PR TITLE
feature/EB-3000131432" Hide coinbase wallet when user try from mobile device

### DIFF
--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -25,7 +25,7 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
       connector: coinbaseWallet,
       name: 'Coinbase Wallet',
       iconType: 'coinbaseWallet',
-      description: 'Use Coinbase Wallet app on mobile device',
+      description: 'Connect to Coinbase Wallet',
       href: null,
     },
   }),

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -1,5 +1,6 @@
 import { WalletInfo } from 'types';
 import { coinbaseWallet, injected, walletConnect } from 'walletConnectors';
+import { isMobileDevices } from 'utils/isMobile';
 import { PortkeyNameVersion } from '../contexts/usePortkey/constants';
 
 export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
@@ -17,13 +18,17 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
     href: null,
   },
-  COINBASE_WALLET: {
-    connector: coinbaseWallet,
-    name: 'Coinbase Wallet',
-    iconType: 'coinbaseWallet',
-    description: 'Use Coinbase Wallet app on mobile device',
-    href: null,
-  },
+  // Hide coinbase wallet option in mobile device
+  // Ticket EB-3000131432
+  ...(!isMobileDevices() && {
+    COINBASE_WALLET: {
+      connector: coinbaseWallet,
+      name: 'Coinbase Wallet',
+      iconType: 'coinbaseWallet',
+      description: 'Use Coinbase Wallet app on mobile device',
+      href: null,
+    },
+  }),
   NIGHT_ELF: {
     connector: 'NIGHT ELF',
     name: 'NIGHT ELF',


### PR DESCRIPTION
Hide the Coinbase Wallet connection method when the user enters from the mobile environment and connects to the EVM Wallet panel.